### PR TITLE
feat: 環境変数設計

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,3 @@
+ZOOM_SECRET_TOKEN=your_zoom_secret_token
+ZOOM_WEBHOOK_SECRET_TOKEN=your_zoom_webhook_secret_token
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # zoom-discord-notifier
+
 Zoom ミーティングへの入室を Discord に通知する Cloudflare Workers アプリ
+
+## セットアップ
+
+### 環境変数
+
+ローカル開発では `.dev.vars.example` をコピーして `.dev.vars` を作成する。
+
+```bash
+cp .dev.vars.example .dev.vars
+```
+
+本番環境では以下のコマンドで設定する。
+
+```bash
+wrangler secret put ZOOM_SECRET_TOKEN
+wrangler secret put ZOOM_WEBHOOK_SECRET_TOKEN
+wrangler secret put DISCORD_WEBHOOK_URL
+```

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,5 @@
+interface Env {
+	ZOOM_SECRET_TOKEN: string;
+	ZOOM_WEBHOOK_SECRET_TOKEN: string;
+	DISCORD_WEBHOOK_URL: string;
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,8 @@ name = "zoom-discord-notifier"
 main = "src/index.ts"
 compatibility_date = "2024-12-30"
 compatibility_flags = ["nodejs_compat"]
+
+# シークレット変数（wrangler secret put で設定）
+# ZOOM_SECRET_TOKEN - Zoom Webhook の検証トークン
+# ZOOM_WEBHOOK_SECRET_TOKEN - Zoom 署名検証用シークレット
+# DISCORD_WEBHOOK_URL - Discord Incoming Webhook の URL


### PR DESCRIPTION
## Summary

- `Env` インターフェースに 3 つの環境変数を型定義
- `.dev.vars.example` をローカル開発用サンプルとして追加

## 環境変数一覧

| 変数名 | 内容 |
|---|---|
| `ZOOM_SECRET_TOKEN` | Zoom Webhook の検証トークン |
| `ZOOM_WEBHOOK_SECRET_TOKEN` | Zoom 署名検証用シークレット |
| `DISCORD_WEBHOOK_URL` | Discord Incoming Webhook の URL |

## 対応 Issue

Closes #2

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Zoom および Discord 統合の環境変数設定ファイルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->