### PR TITLE
feat: Zoom Webhook 疎通確認エンドポイント実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,22 @@
+import { handleUrlValidation } from "./url-validation";
+
 export default {
-	async fetch(_request: Request, _env: Env): Promise<Response> {
-		return new Response("Hello, World!");
+	async fetch(request: Request, env: Env): Promise<Response> {
+		if (request.method !== "POST") {
+			return new Response("Method Not Allowed", { status: 405 });
+		}
+
+		const body = await request.json<{ event?: string; payload?: { plainToken?: string } }>();
+
+		if (body.event === "endpoint.url_validation") {
+			const plainToken = body.payload?.plainToken;
+			if (!plainToken) {
+				return new Response("Bad Request", { status: 400 });
+			}
+			const result = await handleUrlValidation(plainToken, env.ZOOM_SECRET_TOKEN);
+			return Response.json(result, { status: 200 });
+		}
+
+		return new Response("Not Found", { status: 404 });
 	},
 } satisfies ExportedHandler<Env>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,19 @@ export default {
 			return new Response("Method Not Allowed", { status: 405 });
 		}
 
-		const body = await request.json<{ event?: string; payload?: { plainToken?: string } }>();
+		let body: { event?: string; payload?: { plainToken?: string } };
+		try {
+			body = await request.json();
+		} catch {
+			return new Response("Bad Request", { status: 400 });
+		}
 
 		if (body.event === "endpoint.url_validation") {
 			const plainToken = body.payload?.plainToken;
 			if (!plainToken) {
 				return new Response("Bad Request", { status: 400 });
 			}
-			const result = await handleUrlValidation(plainToken, env.ZOOM_SECRET_TOKEN);
+			const result = handleUrlValidation(plainToken, env.ZOOM_SECRET_TOKEN);
 			return Response.json(result, { status: 200 });
 		}
 

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -5,10 +5,7 @@ export interface UrlValidationResult {
 	encryptedToken: string;
 }
 
-export async function handleUrlValidation(
-	plainToken: string,
-	secretToken: string,
-): Promise<UrlValidationResult> {
+export function handleUrlValidation(plainToken: string, secretToken: string): UrlValidationResult {
 	const encryptedToken = createHmac("sha256", secretToken).update(plainToken).digest("hex");
 	return { plainToken, encryptedToken };
 }

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -1,0 +1,14 @@
+import { createHmac } from "node:crypto";
+
+export interface UrlValidationResult {
+	plainToken: string;
+	encryptedToken: string;
+}
+
+export async function handleUrlValidation(
+	plainToken: string,
+	secretToken: string,
+): Promise<UrlValidationResult> {
+	const encryptedToken = createHmac("sha256", secretToken).update(plainToken).digest("hex");
+	return { plainToken, encryptedToken };
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,9 +1,62 @@
 import { describe, expect, it } from "vitest";
+import worker from "../src/index";
+
+const env = {
+	ZOOM_SECRET_TOKEN: "test_secret",
+	ZOOM_WEBHOOK_SECRET_TOKEN: "test_webhook_secret",
+	DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test",
+} as Env;
+
+const ctx = {
+	waitUntil: () => {},
+	passThroughOnException: () => {},
+} as unknown as ExecutionContext;
 
 describe("Worker", () => {
-	it("エクスポートが存在する", async () => {
-		const worker = await import("../src/index");
-		expect(worker.default).toBeDefined();
-		expect(worker.default.fetch).toBeDefined();
+	it("GET リクエストに 405 を返す", async () => {
+		const request = new Request("http://localhost/", { method: "GET" });
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(405);
+	});
+
+	it("endpoint.url_validation に正しく応答する", async () => {
+		const request = new Request("http://localhost/", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				event: "endpoint.url_validation",
+				payload: { plainToken: "test_plain_token" },
+			}),
+		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(200);
+
+		const body = await response.json<{ plainToken: string; encryptedToken: string }>();
+		expect(body.plainToken).toBe("test_plain_token");
+		expect(body.encryptedToken).toBeTypeOf("string");
+		expect(body.encryptedToken.length).toBeGreaterThan(0);
+	});
+
+	it("plainToken がない場合に 400 を返す", async () => {
+		const request = new Request("http://localhost/", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				event: "endpoint.url_validation",
+				payload: {},
+			}),
+		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(400);
+	});
+
+	it("未知のイベントに 404 を返す", async () => {
+		const request = new Request("http://localhost/", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ event: "unknown.event" }),
+		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(404);
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,6 +50,16 @@ describe("Worker", () => {
 		expect(response.status).toBe(400);
 	});
 
+	it("不正な JSON ボディに 400 を返す", async () => {
+		const request = new Request("http://localhost/", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "invalid json",
+		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(400);
+	});
+
 	it("未知のイベントに 404 を返す", async () => {
 		const request = new Request("http://localhost/", {
 			method: "POST",

--- a/test/url-validation.test.ts
+++ b/test/url-validation.test.ts
@@ -4,26 +4,33 @@ import { handleUrlValidation } from "../src/url-validation";
 const SECRET_TOKEN = "test_secret_token";
 
 describe("handleUrlValidation", () => {
-	it("plainToken と encryptedToken を含むレスポンスを返す", async () => {
+	it("plainToken と encryptedToken を含むレスポンスを返す", () => {
 		const plainToken = "abc123";
-		const result = await handleUrlValidation(plainToken, SECRET_TOKEN);
+		const result = handleUrlValidation(plainToken, SECRET_TOKEN);
 
 		expect(result.plainToken).toBe(plainToken);
 		expect(result.encryptedToken).toBeTypeOf("string");
 		expect(result.encryptedToken.length).toBeGreaterThan(0);
 	});
 
-	it("同じ入力に対して同じ encryptedToken を返す", async () => {
+	it("正しい HMAC-SHA256 値を生成する", () => {
+		const result = handleUrlValidation("abc123", SECRET_TOKEN);
+		expect(result.encryptedToken).toBe(
+			"e2c017c3c4ec55bd4c10b2dfb2f8b18be1f89294aa6cba86070fac35292fb106",
+		);
+	});
+
+	it("同じ入力に対して同じ encryptedToken を返す", () => {
 		const plainToken = "abc123";
-		const result1 = await handleUrlValidation(plainToken, SECRET_TOKEN);
-		const result2 = await handleUrlValidation(plainToken, SECRET_TOKEN);
+		const result1 = handleUrlValidation(plainToken, SECRET_TOKEN);
+		const result2 = handleUrlValidation(plainToken, SECRET_TOKEN);
 
 		expect(result1.encryptedToken).toBe(result2.encryptedToken);
 	});
 
-	it("異なる plainToken に対して異なる encryptedToken を返す", async () => {
-		const result1 = await handleUrlValidation("token1", SECRET_TOKEN);
-		const result2 = await handleUrlValidation("token2", SECRET_TOKEN);
+	it("異なる plainToken に対して異なる encryptedToken を返す", () => {
+		const result1 = handleUrlValidation("token1", SECRET_TOKEN);
+		const result2 = handleUrlValidation("token2", SECRET_TOKEN);
 
 		expect(result1.encryptedToken).not.toBe(result2.encryptedToken);
 	});

--- a/test/url-validation.test.ts
+++ b/test/url-validation.test.ts
@@ -9,8 +9,7 @@ describe("handleUrlValidation", () => {
 		const result = handleUrlValidation(plainToken, SECRET_TOKEN);
 
 		expect(result.plainToken).toBe(plainToken);
-		expect(result.encryptedToken).toBeTypeOf("string");
-		expect(result.encryptedToken.length).toBeGreaterThan(0);
+		expect(result.encryptedToken).toMatch(/^[a-f0-9]{64}$/);
 	});
 
 	it("正しい HMAC-SHA256 値を生成する", () => {

--- a/test/url-validation.test.ts
+++ b/test/url-validation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { handleUrlValidation } from "../src/url-validation";
+
+const SECRET_TOKEN = "test_secret_token";
+
+describe("handleUrlValidation", () => {
+	it("plainToken と encryptedToken を含むレスポンスを返す", async () => {
+		const plainToken = "abc123";
+		const result = await handleUrlValidation(plainToken, SECRET_TOKEN);
+
+		expect(result.plainToken).toBe(plainToken);
+		expect(result.encryptedToken).toBeTypeOf("string");
+		expect(result.encryptedToken.length).toBeGreaterThan(0);
+	});
+
+	it("同じ入力に対して同じ encryptedToken を返す", async () => {
+		const plainToken = "abc123";
+		const result1 = await handleUrlValidation(plainToken, SECRET_TOKEN);
+		const result2 = await handleUrlValidation(plainToken, SECRET_TOKEN);
+
+		expect(result1.encryptedToken).toBe(result2.encryptedToken);
+	});
+
+	it("異なる plainToken に対して異なる encryptedToken を返す", async () => {
+		const result1 = await handleUrlValidation("token1", SECRET_TOKEN);
+		const result2 = await handleUrlValidation("token2", SECRET_TOKEN);
+
+		expect(result1.encryptedToken).not.toBe(result2.encryptedToken);
+	});
+});


### PR DESCRIPTION
## Summary

- Zoom URL Validation（`endpoint.url_validation`）に応答するエンドポイントを実装
- HMAC-SHA256 で `plainToken` から `encryptedToken` を生成
- POST 以外は 405、未知のイベントは 404 を返す

## 対応 Issue

Closes #3

## 変更内容

- `src/url-validation.ts` - HMAC-SHA256 による URL Validation ロジック
- `src/index.ts` - Worker エントリポイントにルーティングを追加
- `test/url-validation.test.ts` - handleUrlValidation の単体テスト（3 件）
- `test/index.test.ts` - Worker 統合テスト（4 件）

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（7 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * URL検証エンドポイントを追加。POSTで受信した検証イベントに対し、プレーンテキストトークンから暗号化トークンを生成してJSONで返却。GET等の不許可メソッドや未知のイベントに対し適切なHTTPステータスで応答し、JSONパースエラーや欠落したトークンは400を返す。

* **テスト**
  * エンドツーエンドと単体の包括的なテストを追加し、正しい応答ステータスと暗号化トークンの一貫性を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->