### PR TITLE
feat: Zoom 署名検証の実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { verifySignature } from "./signature-verification";
 import { handleUrlValidation } from "./url-validation";
 
 export default {
@@ -6,9 +7,10 @@ export default {
 			return new Response("Method Not Allowed", { status: 405 });
 		}
 
+		const rawBody = await request.text();
 		let body: { event?: string; payload?: { plainToken?: string } };
 		try {
-			body = await request.json();
+			body = JSON.parse(rawBody);
 		} catch {
 			return new Response("Bad Request", { status: 400 });
 		}
@@ -20,6 +22,12 @@ export default {
 			}
 			const result = handleUrlValidation(plainToken, env.ZOOM_SECRET_TOKEN);
 			return Response.json(result, { status: 200 });
+		}
+
+		const signature = request.headers.get("x-zm-signature") ?? "";
+		const timestamp = request.headers.get("x-zm-request-timestamp") ?? "";
+		if (!verifySignature(signature, timestamp, rawBody, env.ZOOM_WEBHOOK_SECRET_TOKEN)) {
+			return new Response("Unauthorized", { status: 401 });
 		}
 
 		return new Response("Not Found", { status: 404 });

--- a/src/signature-verification.ts
+++ b/src/signature-verification.ts
@@ -1,0 +1,24 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const TIMESTAMP_TOLERANCE_SECONDS = 300;
+
+export function verifySignature(
+	signature: string,
+	timestamp: string,
+	body: string,
+	secret: string,
+): boolean {
+	const now = Math.floor(Date.now() / 1000);
+	const requestTime = Number.parseInt(timestamp, 10);
+	if (Number.isNaN(requestTime) || now - requestTime > TIMESTAMP_TOLERANCE_SECONDS) {
+		return false;
+	}
+
+	const message = `v0:${timestamp}:${body}`;
+	const expectedSignature = `v0=${createHmac("sha256", secret).update(message).digest("hex")}`;
+
+	if (signature.length !== expectedSignature.length) {
+		return false;
+	}
+	return timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature));
+}

--- a/src/signature-verification.ts
+++ b/src/signature-verification.ts
@@ -10,7 +10,7 @@ export function verifySignature(
 ): boolean {
 	const now = Math.floor(Date.now() / 1000);
 	const requestTime = Number.parseInt(timestamp, 10);
-	if (Number.isNaN(requestTime) || now - requestTime > TIMESTAMP_TOLERANCE_SECONDS) {
+	if (Number.isNaN(requestTime) || Math.abs(now - requestTime) > TIMESTAMP_TOLERANCE_SECONDS) {
 		return false;
 	}
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import worker from "../src/index";
 
@@ -12,6 +13,21 @@ const ctx = {
 	passThroughOnException: () => {},
 } as unknown as ExecutionContext;
 
+function createSignedRequest(body: string): Request {
+	const timestamp = String(Math.floor(Date.now() / 1000));
+	const message = `v0:${timestamp}:${body}`;
+	const hash = createHmac("sha256", env.ZOOM_WEBHOOK_SECRET_TOKEN).update(message).digest("hex");
+	return new Request("http://localhost/", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"x-zm-signature": `v0=${hash}`,
+			"x-zm-request-timestamp": timestamp,
+		},
+		body,
+	});
+}
+
 describe("Worker", () => {
 	it("GET リクエストに 405 を返す", async () => {
 		const request = new Request("http://localhost/", { method: "GET" });
@@ -19,7 +35,7 @@ describe("Worker", () => {
 		expect(response.status).toBe(405);
 	});
 
-	it("endpoint.url_validation に正しく応答する", async () => {
+	it("endpoint.url_validation に正しく応答する（署名不要）", async () => {
 		const request = new Request("http://localhost/", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
@@ -33,8 +49,7 @@ describe("Worker", () => {
 
 		const body = await response.json<{ plainToken: string; encryptedToken: string }>();
 		expect(body.plainToken).toBe("test_plain_token");
-		expect(body.encryptedToken).toBeTypeOf("string");
-		expect(body.encryptedToken.length).toBeGreaterThan(0);
+		expect(body.encryptedToken).toMatch(/^[a-f0-9]{64}$/);
 	});
 
 	it("plainToken がない場合に 400 を返す", async () => {
@@ -60,12 +75,33 @@ describe("Worker", () => {
 		expect(response.status).toBe(400);
 	});
 
-	it("未知のイベントに 404 を返す", async () => {
+	it("署名がないリクエストに 401 を返す", async () => {
 		const request = new Request("http://localhost/", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ event: "unknown.event" }),
+			body: JSON.stringify({ event: "meeting.participant_joined" }),
 		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(401);
+	});
+
+	it("不正な署名のリクエストに 401 を返す", async () => {
+		const request = new Request("http://localhost/", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-zm-signature": "v0=invalid",
+				"x-zm-request-timestamp": String(Math.floor(Date.now() / 1000)),
+			},
+			body: JSON.stringify({ event: "meeting.participant_joined" }),
+		});
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(401);
+	});
+
+	it("正しい署名の未知イベントに 404 を返す", async () => {
+		const body = JSON.stringify({ event: "unknown.event" });
+		const request = createSignedRequest(body);
 		const response = await worker.fetch(request, env, ctx);
 		expect(response.status).toBe(404);
 	});

--- a/test/signature-verification.test.ts
+++ b/test/signature-verification.test.ts
@@ -1,0 +1,44 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifySignature } from "../src/signature-verification";
+
+const SECRET = "test_webhook_secret";
+
+function generateSignature(timestamp: string, body: string, secret: string): string {
+	const message = `v0:${timestamp}:${body}`;
+	const hash = createHmac("sha256", secret).update(message).digest("hex");
+	return `v0=${hash}`;
+}
+
+describe("verifySignature", () => {
+	it("正しい署名で true を返す", () => {
+		const timestamp = String(Math.floor(Date.now() / 1000));
+		const body = '{"event":"meeting.participant_joined"}';
+		const signature = generateSignature(timestamp, body, SECRET);
+
+		expect(verifySignature(signature, timestamp, body, SECRET)).toBe(true);
+	});
+
+	it("不正な署名で false を返す", () => {
+		const timestamp = String(Math.floor(Date.now() / 1000));
+		const body = '{"event":"meeting.participant_joined"}';
+
+		expect(verifySignature("v0=invalid_signature", timestamp, body, SECRET)).toBe(false);
+	});
+
+	it("5分以上前のタイムスタンプで false を返す", () => {
+		const oldTimestamp = String(Math.floor(Date.now() / 1000) - 301);
+		const body = '{"event":"meeting.participant_joined"}';
+		const signature = generateSignature(oldTimestamp, body, SECRET);
+
+		expect(verifySignature(signature, oldTimestamp, body, SECRET)).toBe(false);
+	});
+
+	it("ちょうど5分以内のタイムスタンプで true を返す", () => {
+		const timestamp = String(Math.floor(Date.now() / 1000) - 299);
+		const body = '{"event":"meeting.participant_joined"}';
+		const signature = generateSignature(timestamp, body, SECRET);
+
+		expect(verifySignature(signature, timestamp, body, SECRET)).toBe(true);
+	});
+});

--- a/test/signature-verification.test.ts
+++ b/test/signature-verification.test.ts
@@ -34,6 +34,14 @@ describe("verifySignature", () => {
 		expect(verifySignature(signature, oldTimestamp, body, SECRET)).toBe(false);
 	});
 
+	it("5分以上先の未来タイムスタンプで false を返す", () => {
+		const futureTimestamp = String(Math.floor(Date.now() / 1000) + 301);
+		const body = '{"event":"meeting.participant_joined"}';
+		const signature = generateSignature(futureTimestamp, body, SECRET);
+
+		expect(verifySignature(signature, futureTimestamp, body, SECRET)).toBe(false);
+	});
+
 	it("ちょうど5分以内のタイムスタンプで true を返す", () => {
 		const timestamp = String(Math.floor(Date.now() / 1000) - 299);
 		const body = '{"event":"meeting.participant_joined"}';


### PR DESCRIPTION
## Summary

- HMAC-SHA256 による `x-zm-signature` ヘッダーの署名検証を実装
- タイムスタンプの有効期限チェック（5 分以内）を実装
- 署名不一致時は 401 Unauthorized を返す
- URL Validation は署名検証をスキップ（Zoom 仕様に準拠）
- タイミング攻撃対策として `timingSafeEqual` を使用

## 対応 Issue

Closes #4

## 変更内容

- `src/signature-verification.ts` - 署名検証ロジック
- `src/index.ts` - 署名検証をルーティングに組み込み、`request.text()` に変更
- `test/signature-verification.test.ts` - 署名検証の単体テスト（4 件）
- `test/index.test.ts` - 署名検証の統合テスト追加（署名なし/不正署名/正しい署名）

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（15 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Webhook リクエストの真正性を検証するセキュリティ機能を追加しました。リクエストの署名とタイムスタンプを確認し、不正なリクエストは 401 エラーで拒否されます。

* **テスト**
  * 署名検証機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->