### PR TITLE
feat: 入室イベント処理の実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
+import { parseParticipantJoined } from "./participant-joined";
 import { verifySignature } from "./signature-verification";
+import type { ZoomWebhookPayload } from "./types";
 import { handleUrlValidation } from "./url-validation";
 
 export default {
@@ -28,6 +30,14 @@ export default {
 		const timestamp = request.headers.get("x-zm-request-timestamp") ?? "";
 		if (!verifySignature(signature, timestamp, rawBody, env.ZOOM_WEBHOOK_SECRET_TOKEN)) {
 			return new Response("Unauthorized", { status: 401 });
+		}
+
+		if (body.event === "meeting.participant_joined") {
+			const data = parseParticipantJoined(body as ZoomWebhookPayload);
+			if (!data) {
+				return new Response("Bad Request", { status: 400 });
+			}
+			return Response.json(data, { status: 200 });
 		}
 
 		return new Response("Not Found", { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { parseParticipantJoined } from "./participant-joined";
 import { verifySignature } from "./signature-verification";
-import type { ZoomWebhookPayload } from "./types";
 import { handleUrlValidation } from "./url-validation";
 
 export default {
@@ -33,7 +32,7 @@ export default {
 		}
 
 		if (body.event === "meeting.participant_joined") {
-			const data = parseParticipantJoined(body as ZoomWebhookPayload);
+			const data = parseParticipantJoined(body);
 			if (!data) {
 				return new Response("Bad Request", { status: 400 });
 			}

--- a/src/participant-joined.ts
+++ b/src/participant-joined.ts
@@ -1,0 +1,13 @@
+import type { ParticipantJoinedData, ZoomWebhookPayload } from "./types";
+
+export function parseParticipantJoined(payload: ZoomWebhookPayload): ParticipantJoinedData | null {
+	if (payload.event !== "meeting.participant_joined") {
+		return null;
+	}
+
+	return {
+		meetingName: payload.payload.object.topic,
+		participantName: payload.payload.object.participant.user_name,
+		joinTime: payload.payload.object.participant.join_time,
+	};
+}

--- a/src/participant-joined.ts
+++ b/src/participant-joined.ts
@@ -1,13 +1,31 @@
-import type { ParticipantJoinedData, ZoomWebhookPayload } from "./types";
+import type { ParticipantJoinedData } from "./types";
 
-export function parseParticipantJoined(payload: ZoomWebhookPayload): ParticipantJoinedData | null {
-	if (payload.event !== "meeting.participant_joined") {
+export function parseParticipantJoined(payload: unknown): ParticipantJoinedData | null {
+	if (typeof payload !== "object" || payload === null) return null;
+
+	const p = payload as {
+		event?: unknown;
+		payload?: {
+			object?: {
+				topic?: unknown;
+				participant?: { user_name?: unknown; join_time?: unknown };
+			};
+		};
+	};
+
+	if (p.event !== "meeting.participant_joined") return null;
+
+	const meetingName = p.payload?.object?.topic;
+	const participantName = p.payload?.object?.participant?.user_name;
+	const joinTime = p.payload?.object?.participant?.join_time;
+
+	if (
+		typeof meetingName !== "string" ||
+		typeof participantName !== "string" ||
+		typeof joinTime !== "string"
+	) {
 		return null;
 	}
 
-	return {
-		meetingName: payload.payload.object.topic,
-		participantName: payload.payload.object.participant.user_name,
-		joinTime: payload.payload.object.participant.join_time,
-	};
+	return { meetingName, participantName, joinTime };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+export interface ZoomWebhookPayload {
+	event: string;
+	payload: {
+		object: {
+			topic: string;
+			participant: {
+				user_name: string;
+				join_time: string;
+			};
+		};
+	};
+}
+
+export interface ParticipantJoinedData {
+	meetingName: string;
+	participantName: string;
+	joinTime: string;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -99,6 +99,33 @@ describe("Worker", () => {
 		expect(response.status).toBe(401);
 	});
 
+	it("meeting.participant_joined イベントで参加者データを返す", async () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "テストミーティング",
+					participant: {
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+		const request = createSignedRequest(JSON.stringify(payload));
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(200);
+
+		const body = await response.json<{
+			meetingName: string;
+			participantName: string;
+			joinTime: string;
+		}>();
+		expect(body.meetingName).toBe("テストミーティング");
+		expect(body.participantName).toBe("田中太郎");
+		expect(body.joinTime).toBe("2026-04-03T10:00:00Z");
+	});
+
 	it("正しい署名の未知イベントに 404 を返す", async () => {
 		const body = JSON.stringify({ event: "unknown.event" });
 		const request = createSignedRequest(body);

--- a/test/participant-joined.test.ts
+++ b/test/participant-joined.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { parseParticipantJoined } from "../src/participant-joined";
-import type { ZoomWebhookPayload } from "../src/types";
 
 describe("parseParticipantJoined", () => {
 	it("ペイロードから参加者名・ミーティング名・入室時刻を取り出す", () => {
-		const payload: ZoomWebhookPayload = {
+		const payload = {
 			event: "meeting.participant_joined",
 			payload: {
 				object: {
@@ -34,8 +33,30 @@ describe("parseParticipantJoined", () => {
 					participant: { user_name: "test", join_time: "2026-04-03T10:00:00Z" },
 				},
 			},
-		} as ZoomWebhookPayload;
+		};
 
 		expect(parseParticipantJoined(payload)).toBeNull();
+	});
+
+	it("payload.object が欠けている場合は null を返す", () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {},
+		};
+
+		expect(parseParticipantJoined(payload)).toBeNull();
+	});
+
+	it("participant が欠けている場合は null を返す", () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: { object: { topic: "test" } },
+		};
+
+		expect(parseParticipantJoined(payload)).toBeNull();
+	});
+
+	it("null を渡した場合は null を返す", () => {
+		expect(parseParticipantJoined(null)).toBeNull();
 	});
 });

--- a/test/participant-joined.test.ts
+++ b/test/participant-joined.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseParticipantJoined } from "../src/participant-joined";
+import type { ZoomWebhookPayload } from "../src/types";
+
+describe("parseParticipantJoined", () => {
+	it("ペイロードから参加者名・ミーティング名・入室時刻を取り出す", () => {
+		const payload: ZoomWebhookPayload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "週次定例ミーティング",
+					participant: {
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+
+		const result = parseParticipantJoined(payload);
+		expect(result).toEqual({
+			meetingName: "週次定例ミーティング",
+			participantName: "田中太郎",
+			joinTime: "2026-04-03T10:00:00Z",
+		});
+	});
+
+	it("イベントが meeting.participant_joined でない場合は null を返す", () => {
+		const payload = {
+			event: "meeting.started",
+			payload: {
+				object: {
+					topic: "test",
+					participant: { user_name: "test", join_time: "2026-04-03T10:00:00Z" },
+				},
+			},
+		} as ZoomWebhookPayload;
+
+		expect(parseParticipantJoined(payload)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- `ZoomWebhookPayload` 型定義を作成
- `meeting.participant_joined` イベントからミーティング名・参加者名・入室時刻を取り出す `parseParticipantJoined` を実装
- Worker のルーティングに入室イベント処理を追加

## 対応 Issue

Closes #5

## 変更内容

- `src/types.ts` - `ZoomWebhookPayload`, `ParticipantJoinedData` 型定義
- `src/participant-joined.ts` - ペイロードパース関数
- `src/index.ts` - 入室イベントのルーティング追加
- `test/participant-joined.test.ts` - 単体テスト（2 件）
- `test/index.test.ts` - 統合テスト追加（入室イベント）

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（19 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 参加者参加イベントのサポートを追加しました。ウェブフック経由で参加者が会議に参加する際に、会議名、参加者名、参加時刻を取得・処理できるようになりました。

* **テスト**
  * 参加者参加イベント処理の包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->