### PR TITLE
feat: Discord 通知送信の実装

### DIFF
--- a/src/discord-notification.ts
+++ b/src/discord-notification.ts
@@ -1,0 +1,31 @@
+import type { ParticipantJoinedData } from "./types";
+
+type FetchFn = typeof fetch;
+
+export interface NotificationResult {
+	ok: boolean;
+}
+
+function formatMessage(data: ParticipantJoinedData): string {
+	const date = new Date(data.joinTime);
+	const hours = String(date.getUTCHours() + 9).padStart(2, "0");
+	const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+	return `[${data.meetingName}] に ${data.participantName} が入室しました（${hours}:${minutes}）`;
+}
+
+export async function sendDiscordNotification(
+	webhookUrl: string,
+	data: ParticipantJoinedData,
+	fetchFn: FetchFn = fetch,
+): Promise<NotificationResult> {
+	try {
+		const response = await fetchFn(webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ content: formatMessage(data) }),
+		});
+		return { ok: response.ok };
+	} catch {
+		return { ok: false };
+	}
+}

--- a/src/discord-notification.ts
+++ b/src/discord-notification.ts
@@ -2,13 +2,16 @@ import type { ParticipantJoinedData } from "./types";
 
 type FetchFn = typeof fetch;
 
+const TIMEOUT_MS = 5000;
+
 export interface NotificationResult {
 	ok: boolean;
 }
 
 function formatMessage(data: ParticipantJoinedData): string {
 	const date = new Date(data.joinTime);
-	const hours = String(date.getUTCHours() + 9).padStart(2, "0");
+	const jstHours = (date.getUTCHours() + 9) % 24;
+	const hours = String(jstHours).padStart(2, "0");
 	const minutes = String(date.getUTCMinutes()).padStart(2, "0");
 	return `[${data.meetingName}] に ${data.participantName} が入室しました（${hours}:${minutes}）`;
 }
@@ -19,11 +22,18 @@ export async function sendDiscordNotification(
 	fetchFn: FetchFn = fetch,
 ): Promise<NotificationResult> {
 	try {
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 		const response = await fetchFn(webhookUrl, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ content: formatMessage(data) }),
+			body: JSON.stringify({
+				content: formatMessage(data),
+				allowed_mentions: { parse: [] },
+			}),
+			signal: controller.signal,
 		});
+		clearTimeout(timeoutId);
 		return { ok: response.ok };
 	} catch {
 		return { ok: false };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { sendDiscordNotification } from "./discord-notification";
 import { parseParticipantJoined } from "./participant-joined";
 import { verifySignature } from "./signature-verification";
 import { handleUrlValidation } from "./url-validation";
@@ -36,7 +37,11 @@ export default {
 			if (!data) {
 				return new Response("Bad Request", { status: 400 });
 			}
-			return Response.json(data, { status: 200 });
+			const result = await sendDiscordNotification(env.DISCORD_WEBHOOK_URL, data);
+			if (!result.ok) {
+				return new Response("Bad Gateway", { status: 502 });
+			}
+			return new Response("OK", { status: 200 });
 		}
 
 		return new Response("Not Found", { status: 404 });

--- a/test/discord-notification.test.ts
+++ b/test/discord-notification.test.ts
@@ -24,6 +24,21 @@ describe("sendDiscordNotification", () => {
 
 		const body = JSON.parse(options.body);
 		expect(body.content).toBe("[週次定例] に 田中太郎 が入室しました（19:30）");
+		expect(body.allowed_mentions).toEqual({ parse: [] });
+	});
+
+	it("UTC 15:00 以降の時刻を JST で正しく日跨ぎ変換する", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		const data: ParticipantJoinedData = {
+			meetingName: "夜間会議",
+			participantName: "鈴木一郎",
+			joinTime: "2026-04-03T15:30:00Z",
+		};
+
+		await sendDiscordNotification("https://discord.com/api/webhooks/test/token", data, mockFetch);
+
+		const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+		expect(body.content).toBe("[夜間会議] に 鈴木一郎 が入室しました（00:30）");
 	});
 
 	it("POST 失敗時に ok: false を返す", async () => {

--- a/test/discord-notification.test.ts
+++ b/test/discord-notification.test.ts
@@ -58,6 +58,27 @@ describe("sendDiscordNotification", () => {
 		expect(result.ok).toBe(false);
 	});
 
+	it("タイムアウト（AbortError）時に ok: false を返す", async () => {
+		const mockFetch = vi.fn().mockImplementation(() => {
+			const error = new Error("The operation was aborted");
+			error.name = "AbortError";
+			return Promise.reject(error);
+		});
+		const data: ParticipantJoinedData = {
+			meetingName: "test",
+			participantName: "test",
+			joinTime: "2026-04-03T10:00:00Z",
+		};
+
+		const result = await sendDiscordNotification(
+			"https://discord.com/api/webhooks/test/token",
+			data,
+			mockFetch,
+		);
+
+		expect(result.ok).toBe(false);
+	});
+
 	it("ネットワークエラー時に ok: false を返す", async () => {
 		const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
 		const data: ParticipantJoinedData = {

--- a/test/discord-notification.test.ts
+++ b/test/discord-notification.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendDiscordNotification } from "../src/discord-notification";
+import type { ParticipantJoinedData } from "../src/types";
+
+describe("sendDiscordNotification", () => {
+	it("Discord Webhook に正しいメッセージを POST する", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		const webhookUrl = "https://discord.com/api/webhooks/test/token";
+		const data: ParticipantJoinedData = {
+			meetingName: "週次定例",
+			participantName: "田中太郎",
+			joinTime: "2026-04-03T10:30:00Z",
+		};
+
+		const result = await sendDiscordNotification(webhookUrl, data, mockFetch);
+
+		expect(result.ok).toBe(true);
+		expect(mockFetch).toHaveBeenCalledOnce();
+
+		const [url, options] = mockFetch.mock.calls[0];
+		expect(url).toBe(webhookUrl);
+		expect(options.method).toBe("POST");
+		expect(options.headers["Content-Type"]).toBe("application/json");
+
+		const body = JSON.parse(options.body);
+		expect(body.content).toBe("[週次定例] に 田中太郎 が入室しました（19:30）");
+	});
+
+	it("POST 失敗時に ok: false を返す", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+		const data: ParticipantJoinedData = {
+			meetingName: "test",
+			participantName: "test",
+			joinTime: "2026-04-03T10:00:00Z",
+		};
+
+		const result = await sendDiscordNotification(
+			"https://discord.com/api/webhooks/test/token",
+			data,
+			mockFetch,
+		);
+
+		expect(result.ok).toBe(false);
+	});
+
+	it("ネットワークエラー時に ok: false を返す", async () => {
+		const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+		const data: ParticipantJoinedData = {
+			meetingName: "test",
+			participantName: "test",
+			joinTime: "2026-04-03T10:00:00Z",
+		};
+
+		const result = await sendDiscordNotification(
+			"https://discord.com/api/webhooks/test/token",
+			data,
+			mockFetch,
+		);
+
+		expect(result.ok).toBe(false);
+	});
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 
 const env = {
@@ -29,6 +29,14 @@ function createSignedRequest(body: string): Request {
 }
 
 describe("Worker", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 200 })));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("GET リクエストに 405 を返す", async () => {
 		const request = new Request("http://localhost/", { method: "GET" });
 		const response = await worker.fetch(request, env, ctx);
@@ -99,7 +107,7 @@ describe("Worker", () => {
 		expect(response.status).toBe(401);
 	});
 
-	it("meeting.participant_joined イベントで参加者データを返す", async () => {
+	it("meeting.participant_joined で Discord 通知を送信し 200 を返す", async () => {
 		const payload = {
 			event: "meeting.participant_joined",
 			payload: {
@@ -116,14 +124,30 @@ describe("Worker", () => {
 		const response = await worker.fetch(request, env, ctx);
 		expect(response.status).toBe(200);
 
-		const body = await response.json<{
-			meetingName: string;
-			participantName: string;
-			joinTime: string;
-		}>();
-		expect(body.meetingName).toBe("テストミーティング");
-		expect(body.participantName).toBe("田中太郎");
-		expect(body.joinTime).toBe("2026-04-03T10:00:00Z");
+		const mockFetch = vi.mocked(fetch);
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const [url] = mockFetch.mock.calls[0];
+		expect(url).toBe(env.DISCORD_WEBHOOK_URL);
+	});
+
+	it("Discord 通知失敗時に 502 を返す", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("error", { status: 500 })));
+
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "テスト",
+					participant: {
+						user_name: "テスト",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+		const request = createSignedRequest(JSON.stringify(payload));
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(502);
 	});
 
 	it("正しい署名の未知イベントに 404 を返す", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,6 +34,7 @@ describe("Worker", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
 	});
 


### PR DESCRIPTION
## Summary

- Discord Incoming Webhook へ入室通知メッセージを POST する `sendDiscordNotification` を実装
- メッセージ形式: `[ミーティング名] に 参加者名 が入室しました（HH:MM）`
- POST 失敗/ネットワークエラー時は `ok: false` を返し、Worker は 502 を返す
- fetch をモックした単体テストと統合テストを追加

## 対応 Issue

Closes #6

## 変更内容

- `src/discord-notification.ts` - Discord 通知送信ロジック
- `src/index.ts` - 入室イベント処理に Discord 通知を組み込み
- `test/discord-notification.test.ts` - 単体テスト（3 件）
- `test/index.test.ts` - 統合テスト更新（Discord 通知成功/失敗）

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（26 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ミーティング参加時に Discord へ自動通知を送信する機能を追加しました。参加者名、ミーティング名、参加時刻（JST 表示）を含むメッセージが Webhook 経由で配信されます。

* **改善**
  * 通知送信に 5 秒タイムアウトと失敗検出を導入し、送信失敗時は 502 Bad Gateway を返すようにしました。

* **テスト**
  * メッセージ内容、時刻変換（JST 日付境界含む）、成功／失敗（HTTP 非2xx、例外、タイムアウト）を網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->