### PR TITLE
feat: Cloudflare Workers デプロイ設定（GitHub Actions）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run test
+
+      - run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   deploy:
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ wrangler secret put ZOOM_SECRET_TOKEN
 wrangler secret put ZOOM_WEBHOOK_SECRET_TOKEN
 wrangler secret put DISCORD_WEBHOOK_URL
 ```
+
+### GitHub Actions（自動デプロイ）
+
+`main` ブランチへのマージ時に Cloudflare Workers へ自動デプロイされる。
+
+リポジトリの Settings > Secrets and variables > Actions に以下を登録する。
+
+| Secret 名 | 内容 |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare Workers 用 API トークン |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare アカウント ID |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ wrangler secret put DISCORD_WEBHOOK_URL
 
 ### GitHub Actions（自動デプロイ）
 
-`main` ブランチへのマージ時に Cloudflare Workers へ自動デプロイされる。
+`main` ブランチへの push 時に Cloudflare Workers へ自動デプロイされる。
 
 リポジトリの Settings > Secrets and variables > Actions に以下を登録する。
 


### PR DESCRIPTION
## Summary

- `main` マージ時に lint / test / deploy を実行する GitHub Actions ワークフローを作成
- 権限は `contents: read` のみに制限
- README に `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` の GitHub Secrets 設定手順を追記

## 対応 Issue

Closes #7

## 変更内容

- `.github/workflows/deploy.yml` - デプロイワークフロー
- `README.md` - GitHub Secrets のセットアップ手順を追記

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（28 テスト通過）
- [ ] GitHub Secrets 設定後、main マージ時にデプロイが実行される（要手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * mainブランチへのプッシュでCloudflare Workersへ自動デプロイが行われるようになりました。

* **ドキュメント**
  * 自動デプロイの有効化手順と、必要なCloudflare認証情報の登録方法をREADMEに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->