### PR TITLE
feat: 特定の Zoom ミーティングのみ通知するフィルタを追加

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,4 @@
 ZOOM_SECRET_TOKEN=your_zoom_secret_token
 ZOOM_WEBHOOK_SECRET_TOKEN=your_zoom_webhook_secret_token
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
+ZOOM_MEETING_ID=your_zoom_meeting_id

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,4 +2,5 @@ interface Env {
 	ZOOM_SECRET_TOKEN: string;
 	ZOOM_WEBHOOK_SECRET_TOKEN: string;
 	DISCORD_WEBHOOK_URL: string;
+	ZOOM_MEETING_ID: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,9 @@ export default {
 		}
 
 		const meetingId = (body as { payload?: { object?: { id?: unknown } } }).payload?.object?.id;
+		if (meetingId === undefined || meetingId === null) {
+			return new Response("Bad Request", { status: 400 });
+		}
 		if (String(meetingId) !== env.ZOOM_MEETING_ID) {
 			return new Response("OK", { status: 200 });
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ export default {
 			return new Response("Unauthorized", { status: 401 });
 		}
 
+		const meetingId = (body as { payload?: { object?: { id?: unknown } } }).payload?.object?.id;
+		if (String(meetingId) !== env.ZOOM_MEETING_ID) {
+			return new Response("OK", { status: 200 });
+		}
+
 		if (body.event === "meeting.participant_joined") {
 			const data = parseParticipantJoined(body);
 			if (!data) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,7 @@ const env = {
 	ZOOM_SECRET_TOKEN: "test_secret",
 	ZOOM_WEBHOOK_SECRET_TOKEN: "test_webhook_secret",
 	DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test",
+	ZOOM_MEETING_ID: "123456789",
 } as Env;
 
 const ctx = {
@@ -108,11 +109,34 @@ describe("Worker", () => {
 		expect(response.status).toBe(401);
 	});
 
-	it("meeting.participant_joined で Discord 通知を送信し 200 を返す", async () => {
+	it("ミーティング ID が一致しない場合は 200 を返し通知しない", async () => {
 		const payload = {
 			event: "meeting.participant_joined",
 			payload: {
 				object: {
+					id: 999999999,
+					topic: "別のミーティング",
+					participant: {
+						user_name: "テスト",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+		const request = createSignedRequest(JSON.stringify(payload));
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(200);
+
+		const mockFetch = vi.mocked(fetch);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("ミーティング ID が一致する場合は Discord 通知を送信し 200 を返す", async () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					id: 123456789,
 					topic: "テストミーティング",
 					participant: {
 						user_name: "田中太郎",
@@ -138,6 +162,7 @@ describe("Worker", () => {
 			event: "meeting.participant_joined",
 			payload: {
 				object: {
+					id: 123456789,
 					topic: "テスト",
 					participant: {
 						user_name: "テスト",
@@ -152,7 +177,10 @@ describe("Worker", () => {
 	});
 
 	it("正しい署名の未知イベントに 404 を返す", async () => {
-		const body = JSON.stringify({ event: "unknown.event" });
+		const body = JSON.stringify({
+			event: "unknown.event",
+			payload: { object: { id: 123456789 } },
+		});
 		const request = createSignedRequest(body);
 		const response = await worker.fetch(request, env, ctx);
 		expect(response.status).toBe(404);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -109,6 +109,16 @@ describe("Worker", () => {
 		expect(response.status).toBe(401);
 	});
 
+	it("ミーティング ID が欠落している場合は 400 を返す", async () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: { object: { topic: "テスト" } },
+		};
+		const request = createSignedRequest(JSON.stringify(payload));
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(400);
+	});
+
 	it("ミーティング ID が一致しない場合は 200 を返し通知しない", async () => {
 		const payload = {
 			event: "meeting.participant_joined",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,4 @@ compatibility_flags = ["nodejs_compat"]
 # ZOOM_SECRET_TOKEN - Zoom Webhook の検証トークン
 # ZOOM_WEBHOOK_SECRET_TOKEN - Zoom 署名検証用シークレット
 # DISCORD_WEBHOOK_URL - Discord Incoming Webhook の URL
+# ZOOM_MEETING_ID - 通知対象のミーティング ID


### PR DESCRIPTION
## Summary

- 環境変数 `ZOOM_MEETING_ID` で通知対象のミーティングを絞り込む
- ID が一致しないイベントは 200 OK を返し Zoom のリトライを防ぐ
- パーソナルミーティング等の不要な通知を除外

## 対応 Issue

Closes #18

## 変更内容

- `src/env.d.ts` - `ZOOM_MEETING_ID: string` を追加
- `src/index.ts` - 署名検証後にミーティング ID フィルタを挿入
- `.dev.vars.example` - サンプル値を追加
- `wrangler.toml` - コメントに変数名を追加
- `test/index.test.ts` - フィルタのテスト追加（ID 一致/不一致）

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（29 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Zoom ミーティング ID によるイベントフィルタリングを追加。指定したミーティングからのイベントのみ処理します。

* **設定**
  * 新しい環境変数「ZOOM_MEETING_ID」を追加し、対象ミーティングを指定可能にしました。

* **テスト**
  * ミーティングIDの有無・一致・不一致ケースを含むテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->