### PR TITLE
feat: 会議室の表示名をカスタマイズ可能にする

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -2,3 +2,4 @@ ZOOM_SECRET_TOKEN=your_zoom_secret_token
 ZOOM_WEBHOOK_SECRET_TOKEN=your_zoom_webhook_secret_token
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
 ZOOM_MEETING_ID=your_zoom_meeting_id
+MEETING_DISPLAY_NAME=your_meeting_room_name

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,4 +3,5 @@ interface Env {
 	ZOOM_WEBHOOK_SECRET_TOKEN: string;
 	DISCORD_WEBHOOK_URL: string;
 	ZOOM_MEETING_ID: string;
+	MEETING_DISPLAY_NAME?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,9 @@ export default {
 			if (!data) {
 				return new Response("Bad Request", { status: 400 });
 			}
+			if (env.MEETING_DISPLAY_NAME) {
+				data.meetingName = env.MEETING_DISPLAY_NAME;
+			}
 			const result = await sendDiscordNotification(env.DISCORD_WEBHOOK_URL, data);
 			if (!result.ok) {
 				return new Response("Bad Gateway", { status: 502 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -165,6 +165,32 @@ describe("Worker", () => {
 		expect(url).toBe(env.DISCORD_WEBHOOK_URL);
 	});
 
+	it("MEETING_DISPLAY_NAME 設定時はカスタム名で通知する", async () => {
+		const envWithDisplayName = { ...env, MEETING_DISPLAY_NAME: "オフィス会議室" };
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					id: 123456789,
+					topic: "元のトピック名",
+					participant: {
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+		const request = createSignedRequest(JSON.stringify(payload));
+		const response = await worker.fetch(request, envWithDisplayName, ctx);
+		expect(response.status).toBe(200);
+
+		const mockFetch = vi.mocked(fetch);
+		expect(mockFetch).toHaveBeenCalledOnce();
+		const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+		expect(body.content).toContain("オフィス会議室");
+		expect(body.content).not.toContain("元のトピック名");
+	});
+
 	it("Discord 通知失敗時に 502 を返す", async () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("error", { status: 500 })));
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,4 @@ compatibility_flags = ["nodejs_compat"]
 # ZOOM_WEBHOOK_SECRET_TOKEN - Zoom 署名検証用シークレット
 # DISCORD_WEBHOOK_URL - Discord Incoming Webhook の URL
 # ZOOM_MEETING_ID - 通知対象のミーティング ID
+# MEETING_DISPLAY_NAME - 通知に表示する会議室名（省略時は Zoom の topic を使用）


### PR DESCRIPTION
## Summary

- オプション環境変数 `MEETING_DISPLAY_NAME` で通知の会議室名を上書き可能に
- 未設定時は従来通り Zoom の `topic` を使用
- パーソナルミーティングのデフォルト名問題に対応

## 対応 Issue

Closes #19

## 変更内容

- `src/env.d.ts` - `MEETING_DISPLAY_NAME?: string` を追加
- `src/index.ts` - `parseParticipantJoined` 後に表示名を上書き
- `.dev.vars.example` - サンプル値を追加
- `wrangler.toml` - コメントに変数名を追加
- `test/index.test.ts` - カスタム名のテスト追加

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（31 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **New Features**
  * 会議室の表示名をカスタマイズできるようになりました。環境変数を設定することで、通知に表示される会議名をZoomのトピック名の代わりに指定可能です。設定されない場合は、従来通りZoomのトピック名が使用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->