### PR TITLE
feat: 会議終了イベントの通知を追加

### DIFF
--- a/src/discord-notification.ts
+++ b/src/discord-notification.ts
@@ -1,4 +1,4 @@
-import type { ParticipantJoinedData, ParticipantLeftData } from "./types";
+import type { MeetingEndedData, ParticipantJoinedData, ParticipantLeftData } from "./types";
 
 type FetchFn = typeof fetch;
 
@@ -58,6 +58,15 @@ export async function sendJoinedNotification(
 	fetchFn: FetchFn = fetch,
 ): Promise<NotificationResult> {
 	return postToDiscord(webhookUrl, formatJoinedMessage(data), fetchFn);
+}
+
+export async function sendEndedNotification(
+	webhookUrl: string,
+	data: MeetingEndedData,
+	fetchFn: FetchFn = fetch,
+): Promise<NotificationResult> {
+	const message = `[${data.meetingName}] の会議が終了しました（${formatJstTime(data.endTime)}）`;
+	return postToDiscord(webhookUrl, message, fetchFn);
 }
 
 export async function sendLeftNotification(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
-import { sendJoinedNotification, sendLeftNotification } from "./discord-notification";
-import { decrementCount, incrementCount } from "./participant-count";
+import {
+	sendEndedNotification,
+	sendJoinedNotification,
+	sendLeftNotification,
+} from "./discord-notification";
+import { parseMeetingEnded } from "./meeting-ended";
+import { decrementCount, incrementCount, resetCount } from "./participant-count";
 import { parseParticipantJoined } from "./participant-joined";
 import { parseParticipantLeft } from "./participant-left";
 import { verifySignature } from "./signature-verification";
@@ -72,6 +77,23 @@ export default {
 				participantCount,
 			};
 			const result = await sendLeftNotification(env.DISCORD_WEBHOOK_URL, data);
+			if (!result.ok) {
+				return new Response("Bad Gateway", { status: 502 });
+			}
+			return new Response("OK", { status: 200 });
+		}
+
+		if (body.event === "meeting.ended") {
+			const parsed = parseMeetingEnded(body);
+			if (!parsed) {
+				return new Response("Bad Request", { status: 400 });
+			}
+			await resetCount(env.PARTICIPANT_STORE, env.ZOOM_MEETING_ID);
+			const data = {
+				meetingName: env.MEETING_DISPLAY_NAME || parsed.meetingName,
+				endTime: parsed.endTime,
+			};
+			const result = await sendEndedNotification(env.DISCORD_WEBHOOK_URL, data);
 			if (!result.ok) {
 				return new Response("Bad Gateway", { status: 502 });
 			}

--- a/src/meeting-ended.ts
+++ b/src/meeting-ended.ts
@@ -1,0 +1,26 @@
+import type { MeetingEndedData } from "./types";
+
+export function parseMeetingEnded(payload: unknown): MeetingEndedData | null {
+	if (typeof payload !== "object" || payload === null) return null;
+
+	const p = payload as {
+		event?: unknown;
+		payload?: {
+			object?: {
+				topic?: unknown;
+				end_time?: unknown;
+			};
+		};
+	};
+
+	if (p.event !== "meeting.ended") return null;
+
+	const meetingName = p.payload?.object?.topic;
+	const endTime = p.payload?.object?.end_time;
+
+	if (typeof meetingName !== "string" || typeof endTime !== "string") {
+		return null;
+	}
+
+	return { meetingName, endTime };
+}

--- a/src/meeting-ended.ts
+++ b/src/meeting-ended.ts
@@ -21,6 +21,9 @@ export function parseMeetingEnded(payload: unknown): MeetingEndedData | null {
 	if (typeof meetingName !== "string" || typeof endTime !== "string") {
 		return null;
 	}
+	if (Number.isNaN(Date.parse(endTime))) {
+		return null;
+	}
 
 	return { meetingName, endTime };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,8 @@ export interface ParticipantLeftData {
 	leaveTime: string;
 	participantCount: number;
 }
+
+export interface MeetingEndedData {
+	meetingName: string;
+	endTime: string;
+}

--- a/test/discord-notification.test.ts
+++ b/test/discord-notification.test.ts
@@ -115,4 +115,20 @@ describe("sendEndedNotification", () => {
 		const body = JSON.parse(mockFetch.mock.calls[0][1].body);
 		expect(body.content).toBe("[週次定例] の会議が終了しました（21:00）");
 	});
+
+	it("POST 失敗時に ok: false を返す", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+		const data: MeetingEndedData = {
+			meetingName: "test",
+			endTime: "2026-04-03T12:00:00Z",
+		};
+
+		const result = await sendEndedNotification(
+			"https://discord.com/api/webhooks/test/token",
+			data,
+			mockFetch,
+		);
+
+		expect(result.ok).toBe(false);
+	});
 });

--- a/test/discord-notification.test.ts
+++ b/test/discord-notification.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { sendJoinedNotification, sendLeftNotification } from "../src/discord-notification";
-import type { ParticipantJoinedData, ParticipantLeftData } from "../src/types";
+import {
+	sendEndedNotification,
+	sendJoinedNotification,
+	sendLeftNotification,
+} from "../src/discord-notification";
+import type { MeetingEndedData, ParticipantJoinedData, ParticipantLeftData } from "../src/types";
 
 describe("sendJoinedNotification", () => {
 	it("入室メッセージを人数付きで POST する", async () => {
@@ -90,5 +94,25 @@ describe("sendLeftNotification", () => {
 		);
 
 		expect(result.ok).toBe(false);
+	});
+});
+
+describe("sendEndedNotification", () => {
+	it("終了メッセージを POST する", async () => {
+		const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+		const data: MeetingEndedData = {
+			meetingName: "週次定例",
+			endTime: "2026-04-03T12:00:00Z",
+		};
+
+		const result = await sendEndedNotification(
+			"https://discord.com/api/webhooks/test/token",
+			data,
+			mockFetch,
+		);
+
+		expect(result.ok).toBe(true);
+		const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+		expect(body.content).toBe("[週次定例] の会議が終了しました（21:00）");
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -186,6 +186,40 @@ describe("Worker", () => {
 		expect(body.content).not.toContain("user0");
 	});
 
+	it("meeting.ended で終了通知を送信しカウントをリセットする", async () => {
+		// まず入室させる
+		const joinPayload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					id: 123456789,
+					topic: "テスト",
+					participant: { user_name: "user0", join_time: "2026-04-03T10:00:00Z" },
+				},
+			},
+		};
+		await worker.fetch(createSignedRequest(JSON.stringify(joinPayload)), env, ctx);
+
+		const endedPayload = {
+			event: "meeting.ended",
+			payload: {
+				object: {
+					id: 123456789,
+					topic: "テスト",
+					end_time: "2026-04-03T12:00:00Z",
+				},
+			},
+		};
+		const request = createSignedRequest(JSON.stringify(endedPayload));
+		const response = await worker.fetch(request, env, ctx);
+		expect(response.status).toBe(200);
+
+		const mockFetch = vi.mocked(fetch);
+		const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+		const body = JSON.parse(lastCall[1]?.body as string);
+		expect(body.content).toContain("会議が終了しました");
+	});
+
 	it("正しい署名の未知イベントに 404 を返す", async () => {
 		const body = JSON.stringify({
 			event: "unknown.event",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -214,10 +214,19 @@ describe("Worker", () => {
 		const response = await worker.fetch(request, env, ctx);
 		expect(response.status).toBe(200);
 
+		// KV のカウントがリセットされていることを検証
+		expect(await env.PARTICIPANT_STORE.get("count:123456789")).toBeNull();
+
 		const mockFetch = vi.mocked(fetch);
 		const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
 		const body = JSON.parse(lastCall[1]?.body as string);
 		expect(body.content).toContain("会議が終了しました");
+
+		// 終了後の再入室で 1 名から始まることを検証
+		await worker.fetch(createSignedRequest(JSON.stringify(joinPayload)), env, ctx);
+		const rejoinCall = vi.mocked(fetch).mock.calls[vi.mocked(fetch).mock.calls.length - 1];
+		const rejoinBody = JSON.parse(rejoinCall[1]?.body as string);
+		expect(rejoinBody.content).toContain("現在 1 名参加中");
 	});
 
 	it("正しい署名の未知イベントに 404 を返す", async () => {

--- a/test/meeting-ended.test.ts
+++ b/test/meeting-ended.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseMeetingEnded } from "../src/meeting-ended";
+
+describe("parseMeetingEnded", () => {
+	it("ペイロードからミーティング名と終了時刻を取り出す", () => {
+		const payload = {
+			event: "meeting.ended",
+			payload: {
+				object: {
+					topic: "テストミーティング",
+					end_time: "2026-04-03T12:00:00Z",
+				},
+			},
+		};
+
+		const result = parseMeetingEnded(payload);
+		expect(result).toEqual({
+			meetingName: "テストミーティング",
+			endTime: "2026-04-03T12:00:00Z",
+		});
+	});
+
+	it("イベントが meeting.ended でない場合は null を返す", () => {
+		const payload = { event: "meeting.started", payload: { object: { topic: "test" } } };
+		expect(parseMeetingEnded(payload)).toBeNull();
+	});
+
+	it("payload.object が欠けている場合は null を返す", () => {
+		const payload = { event: "meeting.ended", payload: {} };
+		expect(parseMeetingEnded(payload)).toBeNull();
+	});
+
+	it("null を渡した場合は null を返す", () => {
+		expect(parseMeetingEnded(null)).toBeNull();
+	});
+});

--- a/test/meeting-ended.test.ts
+++ b/test/meeting-ended.test.ts
@@ -30,6 +30,19 @@ describe("parseMeetingEnded", () => {
 		expect(parseMeetingEnded(payload)).toBeNull();
 	});
 
+	it("end_time が不正な日時フォーマットの場合は null を返す", () => {
+		const payload = {
+			event: "meeting.ended",
+			payload: {
+				object: {
+					topic: "テスト",
+					end_time: "invalid-date",
+				},
+			},
+		};
+		expect(parseMeetingEnded(payload)).toBeNull();
+	});
+
 	it("null を渡した場合は null を返す", () => {
 		expect(parseMeetingEnded(null)).toBeNull();
 	});


### PR DESCRIPTION
## Summary

- `meeting.ended` イベントを処理し Discord に終了通知を送信
- KV の参加者カウントをリセット
- メッセージ形式: `[会議室名] の会議が終了しました（HH:MM）`
- `MEETING_DISPLAY_NAME` による表示名上書きにも対応

## 対応 Issue

Closes #21

## 変更内容

- `src/meeting-ended.ts` - 新規。終了イベントのパース
- `src/types.ts` - `MeetingEndedData` を追加
- `src/discord-notification.ts` - `sendEndedNotification` を追加
- `src/index.ts` - `meeting.ended` イベントハンドラを追加
- `test/meeting-ended.test.ts` - 新規。単体テスト
- `test/discord-notification.test.ts` - 終了通知のテスト追加
- `test/index.test.ts` - 統合テスト追加

## Zoom 側の設定

Event Subscriptions に「End Meeting」を追加する必要がある

## Test plan

- [x] `npm run lint` が正常終了する
- [x] `npm run test` が正常終了する（46 テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 会議終了時に Discord へ自動通知を送信する機能を追加しました。会議の終了時刻と会議名が通知に含まれます。

* **テスト**
  * 会議終了イベントの処理とディスコード通知機能に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->