### PR TITLE
fix: package-lock.json を更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,7 +1729,6 @@
 			"integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.1.2",
 				"pathe": "^2.0.3"
@@ -1744,7 +1743,6 @@
 			"integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/pretty-format": "4.1.2",
 				"@vitest/utils": "4.1.2",
@@ -2655,7 +2653,6 @@
 			"integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.2",
 				"@vitest/mocker": "4.1.2",


### PR DESCRIPTION
## Summary

- `npm ci` の同期エラーを解消するため `package-lock.json` を再生成

## 背景

GitHub Actions の `npm ci` で `package.json` と `package-lock.json` の不一致エラーが発生していた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)