### PR TITLE
fix: package-lock.json をクリーン再生成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,31 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
## Summary

- `node_modules` と `package-lock.json` を完全に削除してから `npm install` でクリーン再生成
- `@emnapi/runtime@1.9.2` と `@emnapi/core@1.9.2` の依存が正しく解決されるようになった
- ローカルで `npm ci` が成功することを確認済み

## 背景

GitHub Actions の `npm ci` で `package.json` と `package-lock.json` の不一致エラーが発生していた。前回の修正（PR #28）では不十分だったため、クリーン再生成で対応した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)