### PR TITLE
fix: 参加者セット管理で再接続時の人数増加と会議終了後の人数不整合を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -295,8 +295,7 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260403.1.tgz",
 			"integrity": "sha512-p6oSNt3yUwcxSoXZ7qCog7+kgQbkSx1Beoci7TMb/xbRF05VR0cO/p1XUE2SLHZ7IgSIc3tNMpFKa0L0fa3Lzg==",
 			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"peer": true
+			"license": "MIT OR Apache-2.0"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -331,7 +330,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -343,6 +341,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -1885,7 +1884,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2333,7 +2331,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2588,7 +2585,6 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -2599,7 +2595,6 @@
 			"integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -2778,7 +2773,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
 	sendLeftNotification,
 } from "./discord-notification";
 import { parseMeetingEnded } from "./meeting-ended";
-import { decrementCount, incrementCount, resetCount } from "./participant-count";
+import { addParticipant, removeParticipant, resetParticipants } from "./participant-count";
 import { parseParticipantJoined } from "./participant-joined";
 import { parseParticipantLeft } from "./participant-left";
 import { verifySignature } from "./signature-verification";
@@ -52,7 +52,11 @@ export default {
 			if (!parsed) {
 				return new Response("Bad Request", { status: 400 });
 			}
-			const participantCount = await incrementCount(env.PARTICIPANT_STORE, env.ZOOM_MEETING_ID);
+			const participantCount = await addParticipant(
+				env.PARTICIPANT_STORE,
+				env.ZOOM_MEETING_ID,
+				parsed.participantId,
+			);
 			const data = {
 				meetingName: env.MEETING_DISPLAY_NAME || parsed.meetingName,
 				joinTime: parsed.joinTime,
@@ -70,7 +74,11 @@ export default {
 			if (!parsed) {
 				return new Response("Bad Request", { status: 400 });
 			}
-			const participantCount = await decrementCount(env.PARTICIPANT_STORE, env.ZOOM_MEETING_ID);
+			const participantCount = await removeParticipant(
+				env.PARTICIPANT_STORE,
+				env.ZOOM_MEETING_ID,
+				parsed.participantId,
+			);
 			const data = {
 				meetingName: env.MEETING_DISPLAY_NAME || parsed.meetingName,
 				leaveTime: parsed.leaveTime,
@@ -88,7 +96,7 @@ export default {
 			if (!parsed) {
 				return new Response("Bad Request", { status: 400 });
 			}
-			await resetCount(env.PARTICIPANT_STORE, env.ZOOM_MEETING_ID);
+			await resetParticipants(env.PARTICIPANT_STORE, env.ZOOM_MEETING_ID);
 			const data = {
 				meetingName: env.MEETING_DISPLAY_NAME || parsed.meetingName,
 				endTime: parsed.endTime,

--- a/src/participant-count.ts
+++ b/src/participant-count.ts
@@ -2,11 +2,7 @@
 // 数値カウンタではなく参加者 ID のセットで管理することで、再接続時の
 // 重複カウント（join が stale な値を読んで increment してしまう問題）を防ぐ。
 // expirationTtl により meeting.ended が届かなかった場合でも古いデータが残らない。
-//
-// TODO: 異なる参加者 ID の同時 join / leave では、双方が stale な読み取りを元に
-// 書き戻すことで一方の更新が失われる lost update が依然として発生しうる。
-// 抜本対策としては Durable Objects によるシリアライズ、もしくは
-// compare-and-set 的なリトライの導入を検討する（無料プランの制約あり）。
+// 異なる参加者の同時 join/leave による lost update は依然として残存する（issue #32 参照）。
 
 const PARTICIPANTS_TTL_SECONDS = 86400; // 24 時間
 

--- a/src/participant-count.ts
+++ b/src/participant-count.ts
@@ -1,27 +1,51 @@
-// NOTE: KV は最終整合性のため、並行リクエストでカウントが不正確になる可能性がある。
-// Durable Objects を使えば原子的な操作が可能だが、無料プランに含まれないため
-// KV を採用している。通知用途ではカウントの多少のずれは許容範囲とする。
-export async function incrementCount(kv: KVNamespace, meetingId: string): Promise<number> {
-	const current = await getCount(kv, meetingId);
-	const next = current + 1;
-	await kv.put(`count:${meetingId}`, String(next));
-	return next;
+// NOTE: KV は最終整合性のため並行リクエストでデータが失われる可能性がある。
+// 数値カウンタではなく参加者 ID のセットで管理することで、再接続時の
+// 重複カウント（join が stale な値を読んで increment してしまう問題）を防ぐ。
+// expirationTtl により meeting.ended が届かなかった場合でも古いデータが残らない。
+
+const PARTICIPANTS_TTL_SECONDS = 86400; // 24 時間
+
+async function getParticipants(kv: KVNamespace, meetingId: string): Promise<Set<string>> {
+	const value = await kv.get(`participants:${meetingId}`);
+	if (value === null) return new Set();
+	try {
+		const parsed = JSON.parse(value);
+		if (Array.isArray(parsed)) return new Set(parsed as string[]);
+	} catch {}
+	return new Set();
 }
 
-export async function decrementCount(kv: KVNamespace, meetingId: string): Promise<number> {
-	const current = await getCount(kv, meetingId);
-	const next = Math.max(0, current - 1);
-	await kv.put(`count:${meetingId}`, String(next));
-	return next;
+export async function addParticipant(
+	kv: KVNamespace,
+	meetingId: string,
+	participantId: string,
+): Promise<number> {
+	const participants = await getParticipants(kv, meetingId);
+	participants.add(participantId);
+	await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
+		expirationTtl: PARTICIPANTS_TTL_SECONDS,
+	});
+	return participants.size;
+}
+
+export async function removeParticipant(
+	kv: KVNamespace,
+	meetingId: string,
+	participantId: string,
+): Promise<number> {
+	const participants = await getParticipants(kv, meetingId);
+	participants.delete(participantId);
+	await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
+		expirationTtl: PARTICIPANTS_TTL_SECONDS,
+	});
+	return participants.size;
+}
+
+export async function resetParticipants(kv: KVNamespace, meetingId: string): Promise<void> {
+	await kv.delete(`participants:${meetingId}`);
 }
 
 export async function getCount(kv: KVNamespace, meetingId: string): Promise<number> {
-	const value = await kv.get(`count:${meetingId}`);
-	if (value === null) return 0;
-	const parsed = Number.parseInt(value, 10);
-	return Number.isNaN(parsed) ? 0 : parsed;
-}
-
-export async function resetCount(kv: KVNamespace, meetingId: string): Promise<void> {
-	await kv.delete(`count:${meetingId}`);
+	const participants = await getParticipants(kv, meetingId);
+	return participants.size;
 }

--- a/src/participant-count.ts
+++ b/src/participant-count.ts
@@ -2,6 +2,11 @@
 // 数値カウンタではなく参加者 ID のセットで管理することで、再接続時の
 // 重複カウント（join が stale な値を読んで increment してしまう問題）を防ぐ。
 // expirationTtl により meeting.ended が届かなかった場合でも古いデータが残らない。
+//
+// TODO: 異なる参加者 ID の同時 join / leave では、双方が stale な読み取りを元に
+// 書き戻すことで一方の更新が失われる lost update が依然として発生しうる。
+// 抜本対策としては Durable Objects によるシリアライズ、もしくは
+// compare-and-set 的なリトライの導入を検討する（無料プランの制約あり）。
 
 const PARTICIPANTS_TTL_SECONDS = 86400; // 24 時間
 
@@ -10,8 +15,13 @@ async function getParticipants(kv: KVNamespace, meetingId: string): Promise<Set<
 	if (value === null) return new Set();
 	try {
 		const parsed = JSON.parse(value);
-		if (Array.isArray(parsed)) return new Set(parsed.filter((item): item is string => typeof item === "string"));
-	} catch {}
+		if (Array.isArray(parsed)) {
+			return new Set(parsed.filter((item): item is string => typeof item === "string"));
+		}
+		console.warn(`participants:${meetingId} is not an array`, { type: typeof parsed });
+	} catch (err) {
+		console.warn(`failed to parse participants:${meetingId}`, err);
+	}
 	return new Set();
 }
 
@@ -21,10 +31,9 @@ export async function addParticipant(
 	participantId: string,
 ): Promise<number> {
 	const participants = await getParticipants(kv, meetingId);
-	if (participants.has(participantId)) {
-		return participants.size;
-	}
 	participants.add(participantId);
+	// NOTE: 既存参加者でも put を実行して TTL をリフレッシュする。
+	// 再接続が続くだけで新規参加者が来ない会議でも TTL 失効を防ぐため。
 	await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
 		expirationTtl: PARTICIPANTS_TTL_SECONDS,
 	});
@@ -37,6 +46,7 @@ export async function removeParticipant(
 	participantId: string,
 ): Promise<number> {
 	const participants = await getParticipants(kv, meetingId);
+	// 不在参加者への leave（stale event や meeting.ended 後の event）は書き戻さない
 	if (!participants.delete(participantId)) {
 		return participants.size;
 	}

--- a/src/participant-count.ts
+++ b/src/participant-count.ts
@@ -21,6 +21,9 @@ export async function addParticipant(
 	participantId: string,
 ): Promise<number> {
 	const participants = await getParticipants(kv, meetingId);
+	if (participants.has(participantId)) {
+		return participants.size;
+	}
 	participants.add(participantId);
 	await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
 		expirationTtl: PARTICIPANTS_TTL_SECONDS,
@@ -34,10 +37,16 @@ export async function removeParticipant(
 	participantId: string,
 ): Promise<number> {
 	const participants = await getParticipants(kv, meetingId);
-	participants.delete(participantId);
-	await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
-		expirationTtl: PARTICIPANTS_TTL_SECONDS,
-	});
+	if (!participants.delete(participantId)) {
+		return participants.size;
+	}
+	if (participants.size === 0) {
+		await kv.delete(`participants:${meetingId}`);
+	} else {
+		await kv.put(`participants:${meetingId}`, JSON.stringify([...participants]), {
+			expirationTtl: PARTICIPANTS_TTL_SECONDS,
+		});
+	}
 	return participants.size;
 }
 

--- a/src/participant-count.ts
+++ b/src/participant-count.ts
@@ -10,7 +10,7 @@ async function getParticipants(kv: KVNamespace, meetingId: string): Promise<Set<
 	if (value === null) return new Set();
 	try {
 		const parsed = JSON.parse(value);
-		if (Array.isArray(parsed)) return new Set(parsed as string[]);
+		if (Array.isArray(parsed)) return new Set(parsed.filter((item): item is string => typeof item === "string"));
 	} catch {}
 	return new Set();
 }

--- a/src/participant-id.ts
+++ b/src/participant-id.ts
@@ -1,0 +1,17 @@
+export function deriveParticipantId(participant: {
+	participant_user_id?: unknown;
+	user_id?: unknown;
+	user_name?: unknown;
+}): string | null {
+	if (typeof participant.participant_user_id === "string" && participant.participant_user_id) {
+		return participant.participant_user_id;
+	}
+	const userId = participant.user_id;
+	if (userId !== undefined && userId !== null && String(userId) !== "0") {
+		return String(userId);
+	}
+	if (typeof participant.user_name === "string" && participant.user_name) {
+		return participant.user_name;
+	}
+	return null;
+}

--- a/src/participant-id.ts
+++ b/src/participant-id.ts
@@ -7,9 +7,9 @@ export function deriveParticipantId(participant: {
 		return participant.participant_user_id;
 	}
 	const userId = participant.user_id;
-	if ((typeof userId === "string" || typeof userId === "number") && String(userId) !== "0") {
+	if (typeof userId === "string" || typeof userId === "number") {
 		const userIdStr = String(userId);
-		if (userIdStr) return userIdStr;
+		if (userIdStr && userIdStr !== "0") return userIdStr;
 	}
 	if (typeof participant.user_name === "string" && participant.user_name) {
 		return participant.user_name;

--- a/src/participant-id.ts
+++ b/src/participant-id.ts
@@ -7,8 +7,9 @@ export function deriveParticipantId(participant: {
 		return participant.participant_user_id;
 	}
 	const userId = participant.user_id;
-	if (userId !== undefined && userId !== null && String(userId) !== "0") {
-		return String(userId);
+	if ((typeof userId === "string" || typeof userId === "number") && String(userId) !== "0") {
+		const userIdStr = String(userId);
+		if (userIdStr) return userIdStr;
 	}
 	if (typeof participant.user_name === "string" && participant.user_name) {
 		return participant.user_name;

--- a/src/participant-joined.ts
+++ b/src/participant-joined.ts
@@ -1,6 +1,9 @@
+import { deriveParticipantId } from "./participant-id";
+
 export interface ParsedJoinEvent {
 	meetingName: string;
 	joinTime: string;
+	participantId: string;
 }
 
 export function parseParticipantJoined(payload: unknown): ParsedJoinEvent | null {
@@ -11,7 +14,12 @@ export function parseParticipantJoined(payload: unknown): ParsedJoinEvent | null
 		payload?: {
 			object?: {
 				topic?: unknown;
-				participant?: { join_time?: unknown };
+				participant?: {
+					participant_user_id?: unknown;
+					user_id?: unknown;
+					user_name?: unknown;
+					join_time?: unknown;
+				};
 			};
 		};
 	};
@@ -19,11 +27,15 @@ export function parseParticipantJoined(payload: unknown): ParsedJoinEvent | null
 	if (p.event !== "meeting.participant_joined") return null;
 
 	const meetingName = p.payload?.object?.topic;
-	const joinTime = p.payload?.object?.participant?.join_time;
+	const participant = p.payload?.object?.participant;
+	const joinTime = participant?.join_time;
 
-	if (typeof meetingName !== "string" || typeof joinTime !== "string") {
+	if (typeof meetingName !== "string" || typeof joinTime !== "string" || !participant) {
 		return null;
 	}
 
-	return { meetingName, joinTime };
+	const participantId = deriveParticipantId(participant);
+	if (!participantId) return null;
+
+	return { meetingName, joinTime, participantId };
 }

--- a/src/participant-left.ts
+++ b/src/participant-left.ts
@@ -1,6 +1,12 @@
-import type { ParticipantLeftData } from "./types";
+import { deriveParticipantId } from "./participant-id";
 
-export function parseParticipantLeft(payload: unknown): ParticipantLeftData | null {
+export interface ParsedLeftEvent {
+	meetingName: string;
+	leaveTime: string;
+	participantId: string;
+}
+
+export function parseParticipantLeft(payload: unknown): ParsedLeftEvent | null {
 	if (typeof payload !== "object" || payload === null) return null;
 
 	const p = payload as {
@@ -8,7 +14,12 @@ export function parseParticipantLeft(payload: unknown): ParticipantLeftData | nu
 		payload?: {
 			object?: {
 				topic?: unknown;
-				participant?: { leave_time?: unknown };
+				participant?: {
+					participant_user_id?: unknown;
+					user_id?: unknown;
+					user_name?: unknown;
+					leave_time?: unknown;
+				};
 			};
 		};
 	};
@@ -16,11 +27,15 @@ export function parseParticipantLeft(payload: unknown): ParticipantLeftData | nu
 	if (p.event !== "meeting.participant_left") return null;
 
 	const meetingName = p.payload?.object?.topic;
-	const leaveTime = p.payload?.object?.participant?.leave_time;
+	const participant = p.payload?.object?.participant;
+	const leaveTime = participant?.leave_time;
 
-	if (typeof meetingName !== "string" || typeof leaveTime !== "string") {
+	if (typeof meetingName !== "string" || typeof leaveTime !== "string" || !participant) {
 		return null;
 	}
 
-	return { meetingName, leaveTime };
+	const participantId = deriveParticipantId(participant);
+	if (!participantId) return null;
+
+	return { meetingName, leaveTime, participantId };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -214,8 +214,8 @@ describe("Worker", () => {
 		const response = await worker.fetch(request, env, ctx);
 		expect(response.status).toBe(200);
 
-		// KV のカウントがリセットされていることを検証
-		expect(await env.PARTICIPANT_STORE.get("count:123456789")).toBeNull();
+		// KV の参加者セットがリセットされていることを検証
+		expect(await env.PARTICIPANT_STORE.get("participants:123456789")).toBeNull();
 
 		const mockFetch = vi.mocked(fetch);
 		const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];

--- a/test/participant-count.test.ts
+++ b/test/participant-count.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { decrementCount, getCount, incrementCount, resetCount } from "../src/participant-count";
+import {
+	addParticipant,
+	getCount,
+	removeParticipant,
+	resetParticipants,
+} from "../src/participant-count";
 
 function createMockKV(): KVNamespace {
 	const store = new Map<string, string>();
@@ -15,38 +20,46 @@ function createMockKV(): KVNamespace {
 }
 
 describe("participant-count", () => {
-	it("incrementCount はカウントを 1 増やして返す", async () => {
+	it("addParticipant は参加者を追加してカウントを返す", async () => {
 		const kv = createMockKV();
-		const count = await incrementCount(kv, "meeting-123");
+		const count = await addParticipant(kv, "meeting-123", "user-a");
 		expect(count).toBe(1);
 	});
 
-	it("incrementCount は連続呼び出しでカウントを増やす", async () => {
+	it("addParticipant は異なる参加者を追加するとカウントが増える", async () => {
 		const kv = createMockKV();
-		await incrementCount(kv, "meeting-123");
-		await incrementCount(kv, "meeting-123");
-		const count = await incrementCount(kv, "meeting-123");
+		await addParticipant(kv, "meeting-123", "user-a");
+		await addParticipant(kv, "meeting-123", "user-b");
+		const count = await addParticipant(kv, "meeting-123", "user-c");
 		expect(count).toBe(3);
 	});
 
-	it("decrementCount はカウントを 1 減らして返す", async () => {
+	it("addParticipant は同じ参加者を重複追加してもカウントが増えない（再接続対策）", async () => {
 		const kv = createMockKV();
-		await incrementCount(kv, "meeting-123");
-		await incrementCount(kv, "meeting-123");
-		const count = await decrementCount(kv, "meeting-123");
+		await addParticipant(kv, "meeting-123", "user-a");
+		await addParticipant(kv, "meeting-123", "user-b");
+		const count = await addParticipant(kv, "meeting-123", "user-a");
+		expect(count).toBe(2);
+	});
+
+	it("removeParticipant は参加者を削除してカウントを返す", async () => {
+		const kv = createMockKV();
+		await addParticipant(kv, "meeting-123", "user-a");
+		await addParticipant(kv, "meeting-123", "user-b");
+		const count = await removeParticipant(kv, "meeting-123", "user-a");
 		expect(count).toBe(1);
 	});
 
-	it("decrementCount は 0 未満にならない", async () => {
+	it("removeParticipant は存在しない参加者を削除しても 0 未満にならない", async () => {
 		const kv = createMockKV();
-		const count = await decrementCount(kv, "meeting-123");
+		const count = await removeParticipant(kv, "meeting-123", "user-a");
 		expect(count).toBe(0);
 	});
 
 	it("getCount は現在のカウントを返す", async () => {
 		const kv = createMockKV();
-		await incrementCount(kv, "meeting-123");
-		await incrementCount(kv, "meeting-123");
+		await addParticipant(kv, "meeting-123", "user-a");
+		await addParticipant(kv, "meeting-123", "user-b");
 		const count = await getCount(kv, "meeting-123");
 		expect(count).toBe(2);
 	});
@@ -57,11 +70,11 @@ describe("participant-count", () => {
 		expect(count).toBe(0);
 	});
 
-	it("resetCount はカウントを 0 にリセットする", async () => {
+	it("resetParticipants はカウントを 0 にリセットする", async () => {
 		const kv = createMockKV();
-		await incrementCount(kv, "meeting-123");
-		await incrementCount(kv, "meeting-123");
-		await resetCount(kv, "meeting-123");
+		await addParticipant(kv, "meeting-123", "user-a");
+		await addParticipant(kv, "meeting-123", "user-b");
+		await resetParticipants(kv, "meeting-123");
 		const count = await getCount(kv, "meeting-123");
 		expect(count).toBe(0);
 	});

--- a/test/participant-count.test.ts
+++ b/test/participant-count.test.ts
@@ -56,6 +56,14 @@ describe("participant-count", () => {
 		expect(count).toBe(0);
 	});
 
+	it("removeParticipant は同じ参加者を重複削除しても 0 未満にならない（冪等性）", async () => {
+		const kv = createMockKV();
+		await addParticipant(kv, "meeting-123", "user-a");
+		await removeParticipant(kv, "meeting-123", "user-a");
+		const count = await removeParticipant(kv, "meeting-123", "user-a");
+		expect(count).toBe(0);
+	});
+
 	it("getCount は現在のカウントを返す", async () => {
 		const kv = createMockKV();
 		await addParticipant(kv, "meeting-123", "user-a");

--- a/test/participant-joined.test.ts
+++ b/test/participant-joined.test.ts
@@ -63,6 +63,25 @@ describe("parseParticipantJoined", () => {
 		expect(result?.participantId).toBe("16778240");
 	});
 
+	it("user_id が \"0\" の場合は user_name にフォールバックする", () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "テスト",
+					participant: {
+						user_id: "0",
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+
+		const result = parseParticipantJoined(payload);
+		expect(result?.participantId).toBe("田中太郎");
+	});
+
 	it("イベントが meeting.participant_joined でない場合は null を返す", () => {
 		const payload = {
 			event: "meeting.started",

--- a/test/participant-joined.test.ts
+++ b/test/participant-joined.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { parseParticipantJoined } from "../src/participant-joined";
 
 describe("parseParticipantJoined", () => {
-	it("ペイロードからミーティング名と入室時刻を取り出す", () => {
+	it("ペイロードからミーティング名・入室時刻・参加者 ID を取り出す", () => {
 		const payload = {
 			event: "meeting.participant_joined",
 			payload: {
@@ -20,7 +20,47 @@ describe("parseParticipantJoined", () => {
 		expect(result).toEqual({
 			meetingName: "週次定例ミーティング",
 			joinTime: "2026-04-03T10:00:00Z",
+			participantId: "田中太郎",
 		});
+	});
+
+	it("participant_user_id がある場合はそれを参加者 ID として使う", () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "テスト",
+					participant: {
+						participant_user_id: "uuid-abc-123",
+						user_id: "99",
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+
+		const result = parseParticipantJoined(payload);
+		expect(result?.participantId).toBe("uuid-abc-123");
+	});
+
+	it("user_id が非ゼロの場合はそれを参加者 ID として使う", () => {
+		const payload = {
+			event: "meeting.participant_joined",
+			payload: {
+				object: {
+					topic: "テスト",
+					participant: {
+						user_id: "16778240",
+						user_name: "田中太郎",
+						join_time: "2026-04-03T10:00:00Z",
+					},
+				},
+			},
+		};
+
+		const result = parseParticipantJoined(payload);
+		expect(result?.participantId).toBe("16778240");
 	});
 
 	it("イベントが meeting.participant_joined でない場合は null を返す", () => {

--- a/test/participant-left.test.ts
+++ b/test/participant-left.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { parseParticipantLeft } from "../src/participant-left";
 
 describe("parseParticipantLeft", () => {
-	it("ペイロードからミーティング名と退室時刻を取り出す", () => {
+	it("ペイロードからミーティング名・退室時刻・参加者 ID を取り出す", () => {
 		const payload = {
 			event: "meeting.participant_left",
 			payload: {
@@ -20,6 +20,7 @@ describe("parseParticipantLeft", () => {
 		expect(result).toEqual({
 			meetingName: "テストミーティング",
 			leaveTime: "2026-04-03T11:00:00Z",
+			participantId: "田中太郎",
 		});
 	});
 


### PR DESCRIPTION
## 問題

2つの事象が報告されていました。

- **再接続時に人数が不当に増える**: 参加者が一瞬落ちて再接続すると、`participant_left` と `participant_joined` がほぼ同時に処理され、`joined` 側が古い（left 前の）KV 値を読んでインクリメントするため、人数が +1 されてしまう
- **会議終了後も 0 人にならない**: `meeting.ended` webhook が届かなかった場合、前回会議の KV データが残留し、次の会議の人数カウントに持ち込まれる

どちらも **Cloudflare KV の最終整合性による read-modify-write 競合**が根本原因です。

## 対策

数値カウンタ (`incrementCount` / `decrementCount`) を廃止し、**参加者 ID のセット**（KV に JSON 配列として保存）で管理するよう変更しました。

### 再接続問題の解消

Set への `add` は冪等なので、`participant_joined` が stale な読み取りで「まだセットにいる」と判断しても人数は増えません。

```
【変更前】count=3, A が再接続
  left  : read 3 → write 2
  joined: read 3（stale）→ write 4  ← バグ

【変更後】set={A,B,C}, A が再接続
  left  : read {A,B,C} → write {B,C}
  joined: read {A,B,C}（stale）→ write {A,B,C}  ← 正しく 3 人
```

### 残留データ問題の解消

KV への書き込みに **`expirationTtl: 86400`（24 時間）** を設定しました。`meeting.ended` が届かなくても自動でデータが消えるため、次の会議に持ち込まれません。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/participant-id.ts` | 新規: 参加者 ID 導出ユーティリティ（優先順位: `participant_user_id` → `user_id` → `user_name`）|
| `src/participant-count.ts` | 数値カウンタ → セット管理 + TTL に書き換え |
| `src/participant-joined.ts` | `participantId` を parse 結果に追加 |
| `src/participant-left.ts` | `participantId` を parse 結果に追加・戻り値型を修正 |
| `src/index.ts` | 新 API (`addParticipant` / `removeParticipant` / `resetParticipants`) に切り替え |
| `test/*.test.ts` | 上記変更に対応したテスト更新（冪等性テスト追加）|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 会議の参加者追跡システムを改善しました。重複した参加者のカウントを防ぎ、より正確な参加者情報を維持するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->