### PR TITLE
fix: deploy ワークフローのエラー・警告と型エラーを解消する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.10",
 				"@cloudflare/workers-types": "^4.20260403.1",
+				"@types/node": "^25.6.0",
 				"typescript": "^6.0.2",
 				"vitest": "^4.1.2",
 				"wrangler": "^4.80.0"
@@ -1689,6 +1690,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -2578,6 +2589,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unenv": {
 			"version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
 		"@cloudflare/workers-types": "^4.20260403.1",
+		"@types/node": "^25.6.0",
 		"typescript": "^6.0.2",
 		"vitest": "^4.1.2",
 		"wrangler": "^4.80.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { verifySignature } from "./signature-verification";
 import { handleUrlValidation } from "./url-validation";
 
 export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
+	async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
 		if (request.method !== "POST") {
 			return new Response("Method Not Allowed", { status: 405 });
 		}

--- a/src/signature-verification.ts
+++ b/src/signature-verification.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 const TIMESTAMP_TOLERANCE_SECONDS = 300;

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { createHmac } from "node:crypto";
 
 export interface UrlValidationResult {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";

--- a/test/participant-joined.test.ts
+++ b/test/participant-joined.test.ts
@@ -63,7 +63,7 @@ describe("parseParticipantJoined", () => {
 		expect(result?.participantId).toBe("16778240");
 	});
 
-	it("user_id が \"0\" の場合は user_name にフォールバックする", () => {
+	it('user_id が "0" の場合は user_name にフォールバックする', () => {
 		const payload = {
 			event: "meeting.participant_joined",
 			payload: {

--- a/test/signature-verification.test.ts
+++ b/test/signature-verification.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { verifySignature } from "../src/signature-verification";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"lib": ["ESNext"],
-		"types": ["@cloudflare/workers-types"],
+		"types": ["@cloudflare/workers-types", "node"],
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"lib": ["ESNext"],
-		"types": ["@cloudflare/workers-types", "node"],
+		"types": ["@cloudflare/workers-types"],
 		"strict": true,
 		"noEmit": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
PR #31 マージ後の deploy ワークフローで発生していたエラー・警告と、`tsc` の型エラーを一括で解消する。

## 対応内容

| Issue | 種別 | 内容 |
|---|---|---|
| #33 | error | biome フォーマットエラーで deploy が失敗していた問題を修正 |
| #34 | type error | `src/index.ts` の fetch ハンドラに `_ctx: ExecutionContext` 引数を追加 |
| #35 | type error | `@types/node` を devDependencies に追加し、`node:crypto` / `Buffer` を使うファイルに `/// <reference types="node" />` を追加 |
| #37 | warning | `actions/checkout` と `actions/setup-node` を v6 に更新（Node.js 20 非推奨警告対応） |

## 型定義方針（Issue #35）

`tsconfig.json` の `types` に `"node"` をグローバル追加すると `@cloudflare/workers-types` と Node.js グローバル型（`Request` / `Response` / `fetch` 等）が衝突する恐れがあるため、必要なファイルにのみ `/// <reference types="node" />` を付与する方式を採用した。結果として `tsconfig.json` への正味の変更はない。

関連する CI 改善タスクは Issue #36 で別途追跡する（`tsc --noEmit` を CI に組み込む）。

## 検証

- `npm run lint` — 通過
- `npm run test` — 53 tests 通過
- `npx tsc --noEmit` — clean（エラーなし）
- `npx wrangler deploy --dry-run` — clean

## Test plan

- [ ] CI（deploy ワークフロー）で Node.js 20 警告が消えていることを確認
- [ ] CI の lint・test ステップが通過することを確認
- [ ] マージ後、Cloudflare Workers へのデプロイが成功することを確認

https://claude.ai/code/session_01NXTk2ZRDA4tHDpGijaQ3sd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローのアクションバージョンを更新しました
  * 開発依存関係に TypeScript の型定義を追加しました
  * 内部ハンドラーシグネチャを更新しました

* **Tests**
  * テスト説明を調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->