### PR TITLE
chore(ci): deploy ワークフローに tsc 型チェックステップを追加する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: npm run lint
 
+      - run: npm run typecheck
+
       - run: npm run test
 
       - run: npx wrangler deploy

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ cp .dev.vars.example .dev.vars
 
 ```bash
 npm ci
-npm run dev      # ローカル開発サーバー起動
-npm run lint     # lint 実行
-npm run test     # テスト実行
+npm run dev       # ローカル開発サーバー起動
+npm run lint      # lint 実行
+npm run typecheck # 型チェック実行
+npm run test      # テスト実行
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"deploy": "wrangler deploy",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
-		"test": "vitest run"
+		"test": "vitest run",
+		"typecheck": "tsc --noEmit"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 		"deploy": "wrangler deploy",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
-		"test": "vitest run",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Issue #36 の対応として、deploy ワークフローに TypeScript の型チェックステップを追加する。

## 対応内容

- `package.json` に `typecheck` スクリプト（`tsc --noEmit`）を追加
- `.github/workflows/deploy.yml` に `npm run typecheck` ステップを `lint` と `test` の間に追加
- `README.md` の開発コマンド一覧にも `npm run typecheck` を追記

## 背景

PR #38 で修正した #34・#35 のような型エラーは、従来の CI（biome + vitest）では検出されず main にマージされていた。`tsc --noEmit` を CI に組み込むことで再発を防止する。

## 検証

- `npm run lint` — 通過
- `npm run typecheck` — clean
- `npm run test` — 53 tests 通過

## Test plan

- [ ] CI で typecheck ステップが通過することを確認
- [ ] 意図的に型エラーを入れた場合に CI が失敗することを確認（任意）

Closes #36

https://claude.ai/code/session_01NXTk2ZRDA4tHDpGijaQ3sd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発ワークフローに型チェック機能を統合しました。品質保証プロセスを強化するため、開発コマンドと自動デプロイメントパイプラインを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->