### PR TITLE
chore(ci): PR トリガーの軽量 CI ワークフローを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - run: npm run test


### PR DESCRIPTION
## 概要

Issue #41 の対応。`pull_request` トリガーの軽量 CI ワークフロー（`.github/workflows/ci.yml`）を追加する。

## 変更内容

- `.github/workflows/ci.yml` を新規作成

## 動作

`main` ブランチへの PR 作成・更新時に以下を実行する（デプロイなし）：

1. `npm ci`
2. `npm run lint`
3. `npm run typecheck`
4. `npm run test`

## 効果

main へのマージ前に型エラー・lint 違反・テスト失敗を PR 上でブロックできる。

## 関連

- Closes #41
- 関連: #36（deploy ワークフローへの typecheck 追加）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発ワークフロー設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->