### PR TITLE
chore(ci): GitHub Actions を SHA ピン留めし Dependabot を設定する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
## 概要

Issue #39 の対応。GitHub Actions の参照をタグ（可変）から コミット SHA（不変）に固定し、Dependabot による自動更新を設定する。

## 変更内容

### SHA ピン留め

対象ファイル: `.github/workflows/deploy.yml`, `.github/workflows/ci.yml`

- `actions/checkout@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2
- `actions/setup-node@v6` → `@53b83947a5a98c8d113130e565377fae1a50d02f` # v6.3.0

バージョン追跡のためインラインコメントで `v6.x.x` を併記。

### Dependabot 設定

`.github/dependabot.yml` を新規作成。

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

毎週 GitHub Actions の新バージョンが出た際に SHA 更新 PR が自動生成される。

## 効果

- Actions のタグ書き換え攻撃（サプライチェーン攻撃）耐性が向上
- CI の再現性が向上（同じ SHA = 同じコード）
- Dependabot により SHA ピン留め運用の手間を軽減

## 関連

- Closes #39
- PR #38 の CodeRabbit レビューで提案された指摘への対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Dependabotを使用した自動依存関係更新チェックの設定を追加（GitHub Actionsおよびnpmパッケージを対象、週次スケジュール）
  * CI/CDワークフローのGitHub Actionsステップを特定のコミットにピン止めしセキュリティを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->