### PR TITLE
docs: README と実装の齟齬を解消する

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm run deploy
 | `CLOUDFLARE_API_TOKEN` | 手順 2 で発行した API トークン |
 | `CLOUDFLARE_ACCOUNT_ID` | 手順 3 で確認したアカウント ID |
 
-`main` ブランチへの push 時に自動デプロイされる。
+`main` ブランチへの push 時に自動デプロイされる。`main` への pull request 時には lint・型チェック・テストのみ実行される（デプロイなし）。
 
 ### 2. Zoom Marketplace アプリの作成
 
@@ -142,6 +142,7 @@ cp .dev.vars.example .dev.vars
 npm ci
 npm run dev       # ローカル開発サーバー起動
 npm run lint      # lint 実行
+npm run lint:fix  # lint の自動修正
 npm run typecheck # 型チェック実行
 npm run test      # テスト実行
 ```


### PR DESCRIPTION
## 概要

README と実装の齟齬を解消する。

## 背景

以下の 2 点が README と実装で食い違っていた：

1. **PR トリガー CI ワークフロー (`ci.yml`) が README に未記載**  
   PR #42 で追加した `.github/workflows/ci.yml` は `main` への PR 時に lint・typecheck・test を実行するが、README の GitHub Actions に関する記述は `main` push 時の自動デプロイのみを説明していた。

2. **`lint:fix` スクリプトが README の「開発」セクションに未記載**  
   `package.json` には `lint:fix` が定義されているが、README の開発コマンド一覧に含まれていなかった。

## 変更内容

`README.md`:
- 「GitHub Actions で自動デプロイする場合」セクションに、PR 時の CI 実行についての一文を追加
- 「開発」セクションの開発コマンド一覧に `npm run lint:fix` を追加

## その他の項目について

以下は齟齬がないことを確認済み：

- 前提条件の Node.js バージョン（22 以上）と CI ワークフローの `node-version` が一致
- Zoom イベント種別（`participant_joined` / `participant_left` / `meeting.ended`）と実装が一致
- 環境変数の記述と `env.d.ts` / `.dev.vars.example` が一致
- システム構成図と実装の流れが一致
- KV namespace の設定手順が正しい